### PR TITLE
fix(renovate): stop rewriting action pin comments on tool version bumps

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,8 +11,9 @@
         '/^\\.github/workflows/.*\\.ya?ml$/',
       ],
       matchStrings: [
-        "uses: commitizen-tools/setup-cz@[a-f0-9]{40}[^\\n]*\\n(?:\\s+with:\\n(?:\\s+[^\\n]+\\n)*?)\\s+version: '(?<currentValue>[^'\\s]+)'",
+        "uses: commitizen-tools/setup-cz@(?<prefix>[a-f0-9]{40}[^\\n]*\\n(?:\\s+with:\\n(?:\\s+[^\\n]+\\n)*?)\\s+version: ')(?<currentValue>[^'\\s]+)'",
       ],
+      autoReplaceStringTemplate: "uses: commitizen-tools/setup-cz@{{{prefix}}}{{{newValue}}}'",
       datasourceTemplate: 'pypi',
       depNameTemplate: 'commitizen',
     },
@@ -57,8 +58,9 @@
         '/^\\.github/workflows/ci\\.ya?ml$/',
       ],
       matchStrings: [
-        "uses: reviewdog/action-setup@[a-f0-9]{40}[^\\n]*\\n(?:\\s+with:\\n(?:\\s+[^\\n]+\\n)*?)\\s+reviewdog_version: '(?<currentValue>[^'\\s]+)'",
+        "uses: reviewdog/action-setup@(?<prefix>[a-f0-9]{40}[^\\n]*\\n(?:\\s+with:\\n(?:\\s+[^\\n]+\\n)*?)\\s+reviewdog_version: ')(?<currentValue>[^'\\s]+)'",
       ],
+      autoReplaceStringTemplate: "uses: reviewdog/action-setup@{{{prefix}}}{{{newValue}}}'",
       datasourceTemplate: 'github-releases',
       depNameTemplate: 'reviewdog/reviewdog',
     },
@@ -79,8 +81,9 @@
         '/^\\.github/workflows/ci\\.ya?ml$/',
       ],
       matchStrings: [
-        "uses: tombi-toml/setup-tombi@[a-f0-9]{40}[^\\n]*\\n(?:\\s+with:\\n(?:\\s+[^\\n]+\\n)*?)\\s+version: '(?<currentValue>[^'\\s]+)'",
+        "uses: tombi-toml/setup-tombi@(?<prefix>[a-f0-9]{40}[^\\n]*\\n(?:\\s+with:\\n(?:\\s+[^\\n]+\\n)*?)\\s+version: ')(?<currentValue>[^'\\s]+)'",
       ],
+      autoReplaceStringTemplate: "uses: tombi-toml/setup-tombi@{{{prefix}}}{{{newValue}}}'",
       datasourceTemplate: 'github-releases',
       depNameTemplate: 'tombi-toml/tombi',
     },
@@ -101,8 +104,9 @@
         '/^\\.github/workflows/ci\\.ya?ml$/',
       ],
       matchStrings: [
-        "uses: j178/prek-action@[a-f0-9]{40}[^\\n]*\\n(?:\\s+with:\\n(?:\\s+[^\\n]+\\n)*?)\\s+prek-version: '(?<currentValue>[^'\\s]+)'",
+        "uses: j178/prek-action@(?<prefix>[a-f0-9]{40}[^\\n]*\\n(?:\\s+with:\\n(?:\\s+[^\\n]+\\n)*?)\\s+prek-version: ')(?<currentValue>[^'\\s]+)'",
       ],
+      autoReplaceStringTemplate: "uses: j178/prek-action@{{{prefix}}}{{{newValue}}}'",
       datasourceTemplate: 'github-releases',
       depNameTemplate: 'j178/prek',
     },

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -233,7 +233,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Tombi
-        uses: tombi-toml/setup-tombi@cc9f0ae573fc213f40bb4844eaa64bceeaf16348 # v1.1.1
+        uses: tombi-toml/setup-tombi@cc9f0ae573fc213f40bb4844eaa64bceeaf16348 # v1.1.0
         with:
           version: '1.1.1'
 


### PR DESCRIPTION
Renovate's custom managers that track a tool version inside an action's `with` block matched the whole `uses:` line, including the digest pin comment. With no `autoReplaceStringTemplate`, Renovate's default replacement rewrites every occurrence of the old value within the match, so a tool version bump also rewrote the action pin comment whenever the tool and the action shared the same version string (e.g. `tombi-toml/tombi` vs `tombi-toml/setup-tombi`).

- Capture the digest, pin comment, and `with` block in a named `prefix` group and add an `autoReplaceStringTemplate` so only the version value is replaced (`commitizen-tools/setup-cz`, `reviewdog/action-setup`, `tombi-toml/setup-tombi`, `j178/prek-action`).
- Restore the `setup-tombi` pin comment to `v1.1.0` to match the pinned digest, which a previous bump had rewritten to `v1.1.1`. The `version: '1.1.1'` input is the tombi CLI version and is unchanged.
