### PR TITLE
ci: cancel superseded pull request workflow runs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   UV_FROZEN: "1"
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ on:
     types: [opened, synchronize, reopened]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:


### PR DESCRIPTION
- Add workflow-level `concurrency` to `.github/workflows/ci.yaml` so a new push to the same PR cancels the superseded run (`cancel-in-progress` only for `pull_request` events).
- Non-PR events (push to `main`, `workflow_dispatch`) use a unique group per run (`github.run_id`), so they always run to completion.
