### PR TITLE
fix(renovate): disable redundant stability gate for lock file maintenance

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -180,6 +180,8 @@
   },
   lockFileMaintenance: {
     automerge: true,
+    // uv's exclude-newer already enforces the cooldown here, so drop the redundant stability gate.
+    minimumReleaseAge: '0 days',
   },
   labels: [
     'automated',


### PR DESCRIPTION
Lock file maintenance PRs (e.g. #425) were force-pushed indefinitely and never automerged: the `renovate/stability-days` check stayed perpetually pending.

Root cause is a conflict between Renovate's `minimumReleaseAge: '3 days'` and uv's `exclude-newer = "3 days"`, both tracking the same moving 3-day boundary. During lock file maintenance Renovate only runs `uv lock`, and uv's `exclude-newer` already enforces the cooldown on the locked versions, so Renovate's stability gate is redundant there and deadlocks.

- Set `minimumReleaseAge: '0 days'` for `lockFileMaintenance` only.
- The global 3-day cooldown still applies to all other update types, and uv keeps enforcing the cooldown for local `uv add` and for lock file maintenance.
